### PR TITLE
fix: handle non-unique VRS ID

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
-module-name = "vrs_index_vcf._core"
+module-name = "vrsix._core"
 python-source = "src"
 
 [tool.pytest.ini_options]

--- a/rust/src/sqlite.rs
+++ b/rust/src/sqlite.rs
@@ -22,9 +22,9 @@ pub async fn setup_db() -> Result<(), Error> {
     let result = sqlx::query(
         "
         CREATE TABLE IF NOT EXISTS vrs_locations (
-            vrs_id VARCHAR(36)
-            PRIMARY KEY NOT NULL,
-            chr VARCHAR(5) NOT NULL,
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            vrs_id TEXT NOT NULL,
+            chr TEXT NOT NULL,
             pos INTEGER NOT NULL
         );",
     )

--- a/src/vrsix/fetch.py
+++ b/src/vrsix/fetch.py
@@ -27,16 +27,10 @@ def fetch_by_vrs_ids(
     :return: location description tuple if available
     """
     conn = _get_connection(db_location)
-    if len(vrs_ids) == 1:
-        result = conn.cursor().execute(
-            "SELECT * FROM vrs_locations WHERE vrs_id = ?", (vrs_ids[0],)
-        )
-        data = [result.fetchone()] if result else []
-    else:
-        result = conn.cursor().execute(
-            "SELECT * FROM vrs_locations WHERE vrs_id IN ?", (vrs_ids,)
-        )
-        data = result.fetchall()
+    result = conn.cursor().execute(
+        "SELECT * FROM vrs_locations WHERE vrs_id IN ?", (vrs_ids,)
+    )
+    data = result.fetchall()
     conn.close()
     return data
 

--- a/src/vrsix/fetch.py
+++ b/src/vrsix/fetch.py
@@ -27,8 +27,12 @@ def fetch_by_vrs_ids(
     :return: location description tuple if available
     """
     conn = _get_connection(db_location)
+    # have to manually make placeholders for python sqlite API --
+    # should still be safe against injection by using parameterized query
+    placeholders = ",".join("?" for _ in vrs_ids)
     result = conn.cursor().execute(
-        "SELECT * FROM vrs_locations WHERE vrs_id IN ?", (vrs_ids,)
+        f"SELECT vrs_id, chr, pos FROM vrs_locations WHERE vrs_id IN ({placeholders})",  # noqa: S608
+        vrs_ids,
     )
     data = result.fetchall()
     conn.close()
@@ -47,7 +51,7 @@ def fetch_by_pos_range(
     """
     conn = _get_connection(db_location)
     result = conn.cursor().execute(
-        "SELECT * FROM vrs_locations WHERE chr = ? AND pos BETWEEN ? AND ?",
+        "SELECT vrs_id, chr, pos FROM vrs_locations WHERE chr = ? AND pos BETWEEN ? AND ?",
         (chrom, start, end),
     )
     data = result.fetchall()


### PR DESCRIPTION
multiple VCF calls could VOCA normalize to the same VRS allele, and multiple rows can use the same chr/pos/ref -- therefore, VRS ID can't be the primary key in a schema and there's no guarantee that a VRS ID fetch will return only one result